### PR TITLE
Adds travis support to jGNUplot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7 
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # jGNUplot #
+[![Build Status](https://travis-ci.org/hopandfork/jgnuplot.svg?branch=master)](https://travis-ci.org/hopandfork/jgnuplot)
 
 JGNUplot is a graphical user interface for gnuplot. So why would somebody
 want to have a user interface for something which is so great because it has


### PR DESCRIPTION
Adds a simple Travis script (it uses the defaults for Maven and
checks against the major SDKs), along with a build status image in
the readme.  At the moment it tells only if "it compiles", but it
can be expanded with more detailed tests.