### PR TITLE
Refactor `runtime` package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
                 <archive>
                     <manifest>
                         <addClasspath>true</addClasspath>
-                        <mainClass>org.hopandfork.jgnuplot.gui.JGP</mainClass>
+                        <mainClass>org.hopandfork.jgnuplot.JGP</mainClass>
                     </manifest>
                 </archive>
             </configuration>

--- a/src/org/hopandfork/jgnuplot/JGP.java
+++ b/src/org/hopandfork/jgnuplot/JGP.java
@@ -93,9 +93,11 @@ import org.hopandfork.jgnuplot.gui.dialog.ConsoleDialog;
 import org.hopandfork.jgnuplot.gui.dialog.PlotDialog;
 import org.hopandfork.jgnuplot.plot.GnuplotVariable;
 import org.hopandfork.jgnuplot.plot.Label;
+import org.hopandfork.jgnuplot.plot.Plot;
+import org.hopandfork.jgnuplot.plot.Plot2D;
+import org.hopandfork.jgnuplot.plot.Plot3D;
 import org.hopandfork.jgnuplot.project.ProjectManager;
 import org.hopandfork.jgnuplot.project.ProjectManagerException;
-import org.hopandfork.jgnuplot.runtime.GnuplotExecutor;
 import org.hopandfork.jgnuplot.runtime.JGPPrintWriter;
 import org.w3c.dom.DOMException;
 import org.xml.sax.SAXException;
@@ -1003,7 +1005,7 @@ public class JGP extends JFrame
 	}
 
 	public void acPrint() {
-		GnuplotExecutor gp = getGNUplot();
+		Plot gp = getGNUplot();
 		gp.setOut((JGPPrintWriter) this);
 		try {
 
@@ -1442,13 +1444,19 @@ public class JGP extends JFrame
 	public void acPlot() throws IOException, InterruptedException {
 		clearShell();
 		println("calling GNUplot...");
-		GnuplotExecutor gp = getGNUplot();
+		Plot gp = getGNUplot();
 		gp.setOut((JGPPrintWriter) this);
 		gp.plotThreaded();
 	}
 
-	public GnuplotExecutor getGNUplot() {
-		GnuplotExecutor gp = new GnuplotExecutor();
+	public Plot getGNUplot() {
+		Plot gp;
+		
+		if (rb2D.isSelected())
+			gp = new Plot2D();
+		else
+			gp = new Plot3D();
+
 		for (int i = 0; i < dsTableModel.data.size(); i++) {
 			gp.dataSets.add(dsTableModel.data.get(i));
 		}
@@ -1511,11 +1519,6 @@ public class JGP extends JFrame
 
 		gp.setPrePlotString(prePlotString.getText() + "\n");
 
-		if (rb2D.isSelected())
-			gp.setPlotType(GnuplotExecutor.PlotType.TWO_DIM);
-		if (rb3D.isSelected())
-			gp.setPlotType(GnuplotExecutor.PlotType.THREE_DIM);
-
 		return gp;
 	}
 
@@ -1553,7 +1556,7 @@ public class JGP extends JFrame
 	}
 
 	public void acGenPlotCmds() {
-		GnuplotExecutor gp = getGNUplot();
+		Plot gp = getGNUplot();
 		String plotString = gp.getPlotString();
 		// taShell.setText( plotString );
 

--- a/src/org/hopandfork/jgnuplot/JGP.java
+++ b/src/org/hopandfork/jgnuplot/JGP.java
@@ -1009,7 +1009,7 @@ public class JGP extends JFrame
 		gp.setOut((JGPPrintWriter) this);
 		try {
 
-			gp.printThreaded("", "");
+			gp.generatePostscriptFile("", "");
 		} catch (IOException e) {
 			showConsole("Error printing: " + e.getMessage(), false, true);
 		} catch (InterruptedException e) {
@@ -1446,7 +1446,7 @@ public class JGP extends JFrame
 		println("calling GNUplot...");
 		Plot gp = getGNUplot();
 		gp.setOut((JGPPrintWriter) this);
-		gp.plotThreaded();
+		gp.plotAndPreview();
 	}
 
 	public Plot getGNUplot() {

--- a/src/org/hopandfork/jgnuplot/data/DataSet.java
+++ b/src/org/hopandfork/jgnuplot/data/DataSet.java
@@ -26,8 +26,8 @@ import java.io.IOException;
 
 import org.hopandfork.jgnuplot.plot.GnuplotColor;
 import org.hopandfork.jgnuplot.plot.PlottingStyle;
-import org.hopandfork.jgnuplot.runtime.GnuplotExecutor;
 import org.hopandfork.jgnuplot.runtime.PreProcessPlugin;
+import org.hopandfork.jgnuplot.runtime.TempFile;
 
 public class DataSet extends PlottableItem {
 
@@ -122,7 +122,7 @@ public class DataSet extends PlottableItem {
 		if (preProcessProgram != null && !preProcessProgram.trim().equals("")
 				&& !preProcessProgram.trim().equals("null")) {
 			// call prepocess program
-			String tmpFileName = GnuplotExecutor.getTempFileName();
+			String tmpFileName = TempFile.getTempFileName();
 			callPreProcessProgram(preProcessProgram.trim(), fileName, tmpFileName);
 			// and plot the tmp output
 			s += "'" + tmpFileName + "'";

--- a/src/org/hopandfork/jgnuplot/gui/dialog/PlotDialog.java
+++ b/src/org/hopandfork/jgnuplot/gui/dialog/PlotDialog.java
@@ -45,7 +45,7 @@ import org.hopandfork.jgnuplot.gui.FileFormatComboBox;
 import org.hopandfork.jgnuplot.gui.FontComboBox;
 import org.hopandfork.jgnuplot.gui.JGPPanel;
 import org.hopandfork.jgnuplot.plot.OutputFileFormat;
-import org.hopandfork.jgnuplot.runtime.GnuplotExecutor;
+import org.hopandfork.jgnuplot.plot.Plot;
 
 
 public class PlotDialog extends JGPDialog implements ActionListener {
@@ -181,7 +181,7 @@ public class PlotDialog extends JGPDialog implements ActionListener {
 
 		owner.println("calling GNUplot...");
 
-		GnuplotExecutor gp = owner.getGNUplot();
+		Plot gp = owner.getGNUplot();
 		
 		gp.psColor = this.cbColor.isSelected();
 		

--- a/src/org/hopandfork/jgnuplot/plot/Plot.java
+++ b/src/org/hopandfork/jgnuplot/plot/Plot.java
@@ -194,12 +194,11 @@ public abstract class Plot {
 		return s;
 	}
 
-	public void plotThreaded() throws IOException, InterruptedException {
+	public void plotAndPreview() throws IOException, InterruptedException {
 		String s = "";
 		s += "set terminal X11 \n";
 		s += getPlotString();
 		// this we have to add to keep the plot window open
-		// s += ("pause -1 'plotting done' \n");
 		s += ("pause -1\n");
 
 		System.out.println("Calling GNUPlotRunner...");
@@ -208,7 +207,7 @@ public abstract class Plot {
 
 	}
 
-	public void printThreaded(String printCmd, String printFile) throws IOException, InterruptedException {
+	public void generatePostscriptFile(String printCmd, String printFile) throws IOException, InterruptedException {
 		String s = "";
 
 		s += "set output '" + printFile + ".ps' \n";

--- a/src/org/hopandfork/jgnuplot/plot/Plot2D.java
+++ b/src/org/hopandfork/jgnuplot/plot/Plot2D.java
@@ -1,0 +1,5 @@
+package org.hopandfork.jgnuplot.plot;
+
+public class Plot2D extends Plot {
+
+}

--- a/src/org/hopandfork/jgnuplot/plot/Plot3D.java
+++ b/src/org/hopandfork/jgnuplot/plot/Plot3D.java
@@ -1,0 +1,21 @@
+package org.hopandfork.jgnuplot.plot;
+
+public class Plot3D extends Plot {
+
+	public Plot3D() {
+		this.plotCommand = "splot";
+	}
+
+	@Override
+	protected String getRangePlotString() {
+		String s = "";
+		s += "[";
+		if (zmin != null)
+			s += zmin;
+		s += ":";
+		if (zmax != null)
+			s += zmax;
+		s += "] ";
+		return s;
+	}
+}

--- a/src/org/hopandfork/jgnuplot/project/ProjectManager.java
+++ b/src/org/hopandfork/jgnuplot/project/ProjectManager.java
@@ -51,9 +51,11 @@ import org.hopandfork.jgnuplot.data.DataSet;
 import org.hopandfork.jgnuplot.data.PlottableItem;
 import org.hopandfork.jgnuplot.plot.GnuplotColor;
 import org.hopandfork.jgnuplot.plot.Label;
+import org.hopandfork.jgnuplot.plot.Plot;
+import org.hopandfork.jgnuplot.plot.Plot2D;
+import org.hopandfork.jgnuplot.plot.Plot3D;
 import org.hopandfork.jgnuplot.plot.PlottingStyle;
 import org.hopandfork.jgnuplot.plot.Variable;
-import org.hopandfork.jgnuplot.runtime.GnuplotExecutor;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -250,7 +252,7 @@ public class ProjectManager extends XMLManager {
 		if (document.getElementsByTagName(PLOT_TYPE).item(0) != null) {
 			String splotType;
 			splotType = document.getElementsByTagName(PLOT_TYPE).item(0).getTextContent();
-			if (splotType.equals(GnuplotExecutor.PlotType.TWO_DIM.toString()))
+			if (splotType.equals(Plot2D.class.getName()))
 				mainWindow.rb2D.setSelected(true);
 			else
 				mainWindow.rb3D.setSelected(true);
@@ -409,11 +411,11 @@ public class ProjectManager extends XMLManager {
 			addTextNode(document, root, VERSION, JGP.getVersion());
 			addTextNode(document, root, TITLE, mainWindow.tfTitle.getText());
 
-			GnuplotExecutor.PlotType plotType;
+			String plotType;
 			if (mainWindow.rb2D.isSelected())
-				plotType = GnuplotExecutor.PlotType.TWO_DIM;
+				plotType = Plot2D.class.getName();
 			else
-				plotType = GnuplotExecutor.PlotType.THREE_DIM;
+				plotType = Plot3D.class.getName();
 			addTextNode(document, root, PLOT_TYPE, plotType.toString());
 
 			addTextNode(document, root, MAX_X, mainWindow.tfMaxX.getText());

--- a/src/org/hopandfork/jgnuplot/runtime/GNUPlotRunner.java
+++ b/src/org/hopandfork/jgnuplot/runtime/GNUPlotRunner.java
@@ -5,39 +5,56 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-public class GNUPlotRunner   extends ProcessRunner{
+/**
+ * Runnable used to asynchronously run GNUplot.
+ */
+public class GNUPlotRunner extends ProcessRunner {
 
+	/** Plot string. */
 	private String gpPlotString;
 
-	private String PLOTFILENAME = "work.gnuplot";
+	/** File to which plot string is written. */
+	private static final String PLOTFILENAME = "work.gnuplot";
 
-	public void run(){
-		try {
-			PrintWriter logWriter = new PrintWriter(new BufferedWriter(new FileWriter(PLOTFILENAME,
-					false)));
+	/** Command to use for running gnuplot. */
+	private static final String GNUPLOT_CMD = "gnuplot";
 
+	public GNUPlotRunner(String plotString, JGPPrintWriter printWriter) {
+		super(printWriter);
+		this.gpPlotString = plotString;
+	}
+	
+	/**
+	 * Writes the plot script to file.
+	 * @param filename Filename for writing to.
+	 * @throws IOException if writing fails.
+	 */
+	private void writePlotScript(String filename) throws IOException
+	{
+			PrintWriter logWriter = new PrintWriter(new BufferedWriter(new FileWriter(filename, false)));
 			logWriter.write(gpPlotString);
 			logWriter.flush();
 			logWriter.close();
+	}
 
-			//System.out.println(GNUplot.GNUPLOT_CMD + PLOTFILENAME);
-			cmdExec(GnuplotExecutor.GNUPLOT_CMD + PLOTFILENAME);
+	/**
+	 * Entry point for GNUPlotRunner.
+	 */
+	public void run() {
+		try {
+			/* Writes plot script to file. */
+			writePlotScript(PLOTFILENAME);
+			
+			/* Runs gnuplot. */
+			cmdExec(GNUPLOT_CMD + " " + PLOTFILENAME);
 
-			System.out.println("GNUplot exited with value: " + p.exitValue()); 
+			System.out.println("GNUplot exited with value: " + p.exitValue());
 			System.out.println("GNUplot has finished.");
 			System.in.read();
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 
-	}
-
-	public String getGpPlotString() {
-		return gpPlotString;
-	}
-
-	public void setGpPlotString(String gpPlotString) {
-		this.gpPlotString = gpPlotString;
 	}
 
 }

--- a/src/org/hopandfork/jgnuplot/runtime/GNUPlotRunner.java
+++ b/src/org/hopandfork/jgnuplot/runtime/GNUPlotRunner.java
@@ -36,6 +36,7 @@ public class GNUPlotRunner extends ProcessRunner {
 			logWriter.flush();
 			logWriter.close();
 	}
+	
 
 	/**
 	 * Entry point for GNUPlotRunner.

--- a/src/org/hopandfork/jgnuplot/runtime/GnuplotExecutor.java
+++ b/src/org/hopandfork/jgnuplot/runtime/GnuplotExecutor.java
@@ -25,31 +25,22 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import org.hopandfork.jgnuplot.data.DataSet;
 import org.hopandfork.jgnuplot.data.PlottableItem;
 import org.hopandfork.jgnuplot.plot.GnuplotVariable;
 import org.hopandfork.jgnuplot.plot.Label;
 import org.hopandfork.jgnuplot.plot.OutputFileFormat;
-import org.hopandfork.jgnuplot.plot.PlottingStyle;
 import org.hopandfork.jgnuplot.plot.StringVariable;
 import org.hopandfork.jgnuplot.plot.Variable;
-import org.hopandfork.jgnuplot.plot.Variable.Type;
 
-public class GnuplotExecutor{
+public class GnuplotExecutor {
 
 	public enum PlotType {
 		TWO_DIM, THREE_DIM
 	}
 
-
 	private JGPPrintWriter out = null;
 
-	public static final String GNUPLOT_CMD = "gnuplot ";
-
-	public static final String PRINT_CMD = "kprinter ";
-
-	public static final String TEMP_DIR = "/tmp";
-
+	private static final String TEMP_DIR = "/tmp";
 
 	public String plotFileName = "work.gnuplot";
 
@@ -104,32 +95,38 @@ public class GnuplotExecutor{
 		variables = new ArrayList<Variable>();
 	}
 
-	public String getPlotString(){
+	public String getPlotString() {
 		String s = "";
 
 		s += prePlotString;
 
-		//Add gnuplot variables to plot string
-		for (int i = 0; i < variables.size(); i++){
-			if (variables.get(i).getType().equals( Variable.Type.GNUPLOT ) ){
+		// Add gnuplot variables to plot string
+		for (int i = 0; i < variables.size(); i++) {
+			if (variables.get(i).getType().equals(Variable.Type.GNUPLOT)) {
 				if (variables.get(i).isActive())
-					s +=  ((GnuplotVariable) variables.get(i)).getPlotString() + "\n" ;
+					s += ((GnuplotVariable) variables.get(i)).getPlotString() + "\n";
 			}
 		}
 
-		//logWriter.write("set title \"" + title + "\" at 500, 0.4  \n");
-		if (title == null) s += "unset title \n";
-		else  s += ("set title \"" + title + "\" \n");
+		if (title == null)
+			s += "unset title \n";
+		else
+			s += ("set title \"" + title + "\" \n");
 
+		if (xlabel == null)
+			s += ("unset xlabel \n");
+		else
+			s += ("set xlabel \"" + xlabel + "\" \n");
 
-		if (xlabel == null)  s += ("unset xlabel \n");
-		else  s += ("set xlabel \"" + xlabel + "\" \n");
+		if (ylabel == null)
+			s += ("unset ylabel \n");
+		else
+			s += ("set ylabel \"" + ylabel + "\" \n");
 
-		if (ylabel == null) s += ("unset ylabel \n");
-		else s += ("set ylabel \"" + ylabel + "\" \n");
-
-		if (zlabel == null) s += ("unset zlabel \n");
-		else s += ("set zlabel \"" + zlabel + "\" \n");
+		if (zlabel == null)
+			s += ("unset zlabel \n");
+		else
+			s += ("set zlabel \"" + zlabel + "\" \n");
 
 		if (logScaleX)
 			s += ("set logscale x \n");
@@ -146,10 +143,10 @@ public class GnuplotExecutor{
 		else
 			s += ("unset logscale z \n");
 
-		for (int i = 0; i < labels.size(); i++){
-			if (labels.get(i).getDoPlot()){
-				s += ( labels.get(i).getPlotString() );
-				s += ( "\n" );		
+		for (int i = 0; i < labels.size(); i++) {
+			if (labels.get(i).getDoPlot()) {
+				s += (labels.get(i).getPlotString());
+				s += ("\n");
 			}
 
 		}
@@ -160,69 +157,71 @@ public class GnuplotExecutor{
 			s += ("splot ");
 
 		s += "[";
-		if (xmin != null) s += xmin;
+		if (xmin != null)
+			s += xmin;
 		s += ":";
-		if (xmax != null) s += xmax;
+		if (xmax != null)
+			s += xmax;
 		s += "] ";
 
 		s += "[";
-		if (ymin != null) s += ymin;
+		if (ymin != null)
+			s += ymin;
 		s += ":";
-		if (ymax != null) s += ymax;
+		if (ymax != null)
+			s += ymax;
 		s += "] ";
 
-		if (plotType == PlotType.TWO_DIM){
+		if (plotType == PlotType.TWO_DIM) {
 			s += "[";
-			if (zmin != null) s += zmin;
+			if (zmin != null)
+				s += zmin;
 			s += ":";
-			if (zmax != null) s += zmax;
+			if (zmax != null)
+				s += zmax;
 			s += "] ";
 		}
 
-		for (int i = 0; i < dataSets.size(); i++){
-			if (dataSets.get(i).isEnabled()){
-				s += ( dataSets.get(i).getPlotString() );
-				s += ( ", " );		
+		for (int i = 0; i < dataSets.size(); i++) {
+			if (dataSets.get(i).isEnabled()) {
+				s += (dataSets.get(i).getPlotString());
+				s += (", ");
 			}
 
 		}
 
 		s = s.trim();
-		//is the a ',' to much at the end?
-		if ( s.lastIndexOf(",") == s.length() - 1)
-			s = s.substring(0,s.length() - 1);
+		// is the a ',' to much at the end?
+		if (s.lastIndexOf(",") == s.length() - 1)
+			s = s.substring(0, s.length() - 1);
 		s += (" \n");
 
-		//Now replace all string variables with their value
-		for (int i = 0; i < variables.size(); i++){
-			if (variables.get(i).getType() == Variable.Type.STRING){
+		// Now replace all string variables with their value
+		for (int i = 0; i < variables.size(); i++) {
+			if (variables.get(i).getType() == Variable.Type.STRING) {
 				if (variables.get(i).isActive())
 					s = ((StringVariable) variables.get(i)).apply(s);
 			}
 		}
 
-
 		return s;
 	}
 
-	public void plotThreaded() throws IOException, InterruptedException{
+	public void plotThreaded() throws IOException, InterruptedException {
 		String s = "";
 		s += "set terminal X11 \n";
 		s += getPlotString();
-		//this we have to add to keep the plot window open
-		//s += ("pause -1 'plotting done' \n");
+		// this we have to add to keep the plot window open
+		// s += ("pause -1 'plotting done' \n");
 		s += ("pause -1\n");
 
 		System.out.println("Calling GNUPlotRunner...");
-		GNUPlotRunner pr = new GNUPlotRunner();
-		pr.setGpPlotString(s);
-		pr.setOut(out);
-		Thread t = new Thread(pr);
-		t.start();
+		GNUPlotRunner pr = new GNUPlotRunner(s,out);
+		new Thread(pr).start();
 
 	}
 
-	public void printThreaded(String printCmd, String printFile) throws IOException, InterruptedException{
+	public void printThreaded(String printCmd, String printFile) throws IOException, InterruptedException {
 		String s = "";
 
 		s += "set output '" + printFile + ".ps' \n";
@@ -235,47 +234,28 @@ public class GnuplotExecutor{
 		s += ("pause -1 'Press ENTER to continue...' \n");
 
 		System.out.println("Calling GNUPlotRunner...");
-		GNUPlotRunner pr = new GNUPlotRunner();
-		pr.setGpPlotString(s);
-		pr.setOut(out);
-		Thread t = new Thread(pr);
-		t.start();
+		GNUPlotRunner pr = new GNUPlotRunner(s,out);
+		new Thread(pr).start();
 	}
 
-
-//	public void genPlotFile(String plotFileName) throws IOException{
-//	PrintWriter logWriter = new PrintWriter(new BufferedWriter(new FileWriter(plotFileName,
-//	false)));
-
-//	String s = getPlotString();
-
-//	s += ("pause -1 'plotting done' \n");
-
-//	logWriter.write(s);
-//	logWriter.flush();
-//	logWriter.close();
-//	}
-
-
-	public void plotToFile(String psFileName, OutputFileFormat format) throws IOException, InterruptedException{
+	public void plotToFile(String psFileName, OutputFileFormat format) throws IOException, InterruptedException {
 
 		String s = "";
 		s += "set output '" + psFileName + "' \n";
 
-		if (format == OutputFileFormat.POSTSCRIPT){
+		if (format == OutputFileFormat.POSTSCRIPT) {
 			s += "set terminal " + format;
 			s += " enhanced ";
-			if (psColor) s += " color ";
-			s += "solid defaultplex "; 
+			if (psColor)
+				s += " color ";
+			s += "solid defaultplex ";
 			s += "'" + psFontName + "' ";
 			s += psFontSize + " ";
-			s += " \n"; 
-		}
-		else if (format == OutputFileFormat.SVG){
+			s += " \n";
+		} else if (format == OutputFileFormat.SVG) {
 			s += "set terminal " + format;
-			s += " \n"; 
-		}
-		else{
+			s += " \n";
+		} else {
 			s += "set terminal " + format;
 			s += " \n";
 		}
@@ -284,76 +264,21 @@ public class GnuplotExecutor{
 		s += "set terminal X11 \n";
 
 		System.out.println("Calling GNUPlotRunner...");
-		GNUPlotRunner pr = new GNUPlotRunner();
-		pr.setGpPlotString(s);
-		pr.setOut(out);
-		Thread t = new Thread(pr);
-		t.start();
-
+		GNUPlotRunner pr = new GNUPlotRunner(s,out);
+		new Thread(pr).start();
 	}
-
-//	public void genPrintFile(String printCmd, String printFile) throws IOException, InterruptedException{
-
-//	PrintWriter logWriter = new PrintWriter(new BufferedWriter(new FileWriter(printFile,
-//	false)));
-
-//	String s = "";
-
-//	s += "set output '" + printFile + ".ps' \n";
-//	s += "set terminal postscript \n";
-
-//	s += getPlotString();
-
-//	s += "set output '|" + printCmd + " " + printFile + "' \n";
-
-//	s += ("pause -1 'Press ENTER to continue...' \n");
-
-//	logWriter.write(s);
-//	logWriter.flush();
-//	logWriter.close();
-
-//	Process p = Runtime.getRuntime().exec("gnuplot " + plotFileName);
-//	p.waitFor();
-
-//	}
-
-	public static void main(String[] args) throws IOException, InterruptedException {
-		GnuplotExecutor gp = new GnuplotExecutor();
-
-		String inFileName = "/home/ccdserv/mxhf/astro/QE/data/diodeMode/diodeMode_minus140C_20051021_pre.dat";
-
-		DataSet ds = new DataSet(inFileName, "1", "($4 * 2)");
-
-		ds.style = PlottingStyle.lines;
-
-		ds.title = "QE";
-
-		gp.setTitle("Quantum efficincy in pdmode");
-
-		gp.xlabel = "x axis";
-
-		gp.ylabel = "y axis";
-
-		gp.dataSets.add( ds );
-
-
-
-
-		gp.plotThreaded();
-	}
-
 
 	/**
-	 * Generates a filename that can be use for temporary files.
-	 * The file will be located in the TEMP_DIR directory.
+	 * Generates a filename that can be use for temporary files. The file will
+	 * be located in the TEMP_DIR directory.
 	 * 
 	 * @return
 	 */
-	public static String getTempFileName(){
+	public static String getTempFileName() {
 		String s = TEMP_DIR + "/jGNUplot";
-		String fn = s + tmpFilnameCounter + ".tmp"; 
+		String fn = s + tmpFilnameCounter + ".tmp";
 
-		while( new File(fn).exists() ){
+		while (new File(fn).exists()) {
 			tmpFilnameCounter++;
 			fn = s + tmpFilnameCounter + ".tmp";
 		}
@@ -480,6 +405,5 @@ public class GnuplotExecutor{
 	public void setZmin(Double zmin) {
 		this.zmin = zmin;
 	}
-
 
 }

--- a/src/org/hopandfork/jgnuplot/runtime/PreProcessPlugin.java
+++ b/src/org/hopandfork/jgnuplot/runtime/PreProcessPlugin.java
@@ -21,11 +21,27 @@
 
 package org.hopandfork.jgnuplot.runtime;
 
+/**
+ * Interface for plugins which can pre-process data files.
+ */
 public interface PreProcessPlugin {
 	
+	/**
+	 * Returns the description of the plugin.
+	 * @return Description of the plugin.
+	 */
 	public String getDescription();
 	
+	/**
+	 * Returns the name of the plugin.
+	 * @return Name of the plugin.
+	 */
 	public String getName();
 	
-	public void PreProcess(String inFileName, String outFileName);
+	/**
+	 * Pre-process specified file.
+	 * @param inFileName Name of the file to pre-process.
+	 * @param outFileName Output file name.
+	 */
+	public void preProcess(String inFileName, String outFileName);
 }

--- a/src/org/hopandfork/jgnuplot/runtime/ProcessRunner.java
+++ b/src/org/hopandfork/jgnuplot/runtime/ProcessRunner.java
@@ -4,64 +4,66 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-public abstract class ProcessRunner  implements Runnable {
+/**
+ * Runnable used to asynchronously run commands.
+ */
+public abstract class ProcessRunner implements Runnable {
 
-	private JGPPrintWriter out = null;
+	/** JGPPrintWriter for logging. */
+	protected JGPPrintWriter out = null;
 
+	/** Launched process. */
+	protected static Process p = null;
+	
+	public ProcessRunner (JGPPrintWriter printWriter) {
+		this.out = printWriter;
+	}
 
-	protected GnuplotExecutor owner;
-	protected static Process p;
-
-
+	/**
+	 * Executes a command on a shell.
+	 * @param cmdline CLI command to run.
+	 */
 	public void cmdExec(String cmdline) {
 		try {
 			String line = null;
 			String errline = null;
 
-			//if there is an older process still running, destroy it.
-			if (p != null) p.destroy();
+			/* If there is an older process still running, destroy it. */
+			synchronized (this) {
+				if (p != null)
+					p.destroy();
+			}
 
+			/* Runs given command. */
 			p = Runtime.getRuntime().exec(cmdline);
-			//InputStreamReader inputStreamReader;
-			BufferedReader input =
-				new BufferedReader
-				(new InputStreamReader(p.getInputStream() ));
 
-			//InputStreamReader errInputStreamReader;
+			BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()));
+			BufferedReader err = new BufferedReader(new InputStreamReader(p.getErrorStream()));
 
-			BufferedReader err =
-				new BufferedReader
-				(new InputStreamReader(p.getErrorStream() ));
-
+			// TODO following code is a bit weird!
 			try {
-				while ( (line = input.readLine()) != null || (errline = err.readLine()) != null) {
-					if (line != null && !line.trim().equals("") && out != null) 
+				while ((line = input.readLine()) != null || (errline = err.readLine()) != null) {
+					if (line != null && !line.trim().equals("") && out != null)
 						out.println(line);
-					if (errline != null &&  !errline.trim().equals("")  && out != null)  
+					if (errline != null && !errline.trim().equals("") && out != null)
 						out.printerrln(errline);
 				}
 			} catch (IOException e) {
 				System.out.println("readLine() failed");
 			}
+			
+			/* Waits for process to terminate. */
 			p.waitFor();
+
 			input.close();
 			err.close();
-		}
-		catch (Exception err) {
+			
+			synchronized (this) {
+				p = null;
+			}
+		} catch (Exception err) {
 			err.printStackTrace();
 		}
 	}
-
-
-
-	public JGPPrintWriter getOut() {
-		return out;
-	}
-
-	public void setOut(JGPPrintWriter out) {
-		this.out = out;
-	}
-
-
 
 }

--- a/src/org/hopandfork/jgnuplot/runtime/TempFile.java
+++ b/src/org/hopandfork/jgnuplot/runtime/TempFile.java
@@ -1,0 +1,28 @@
+package org.hopandfork.jgnuplot.runtime;
+
+import java.io.File;
+
+public class TempFile {
+
+	private static int tmpFilnameCounter = 0;
+	private static final String TEMP_DIR = "/tmp";
+	
+	/**
+	 * Generates a filename that can be use for temporary files. The file will
+	 * be located in the TEMP_DIR directory.
+	 * 
+	 * @return
+	 */
+	public static String getTempFileName() {
+		String s = TEMP_DIR + "/jGNUplot";
+		String fn = s + tmpFilnameCounter + ".tmp";
+
+		while (new File(fn).exists()) {
+			tmpFilnameCounter++;
+			fn = s + tmpFilnameCounter + ".tmp";
+		}
+
+		return fn;
+	}
+
+}


### PR DESCRIPTION
I performed a bit of refactoring in the `runtime` package. 

- I added a few comments in the code
- I renamed some methods in order to use more meaningful names
- I moved `GnuplotExecutor` class into `plot` package and renamed it as `Plot` (indeed it represented the plot entity and 'Executor' was confusing)
- I created the `TempFile` class, moving logic related to temporary files out of `Plot`

I also fixed an issue in `pom.xml`, with generated JAR having a wrong main class.