### PR TITLE
Deprecates classes which require deep refactoring or rewriting

### DIFF
--- a/src/org/hopandfork/jgnuplot/gui/JGPFileFilter.java
+++ b/src/org/hopandfork/jgnuplot/gui/JGPFileFilter.java
@@ -66,6 +66,7 @@ import javax.swing.filechooser.*;
  * @version 1.16 07/26/04
  * @author Jeff Dinkins
  */
+@Deprecated
 public class JGPFileFilter extends FileFilter {
 
     private static String TYPE_UNKNOWN = "Type Unknown";

--- a/src/org/hopandfork/jgnuplot/utility/TempFile.java
+++ b/src/org/hopandfork/jgnuplot/utility/TempFile.java
@@ -2,6 +2,7 @@ package org.hopandfork.jgnuplot.utility;
 
 import java.io.File;
 
+@Deprecated // TODO use File.createTempFile()
 public class TempFile {
 
 	private static int tmpFilnameCounter = 0;

--- a/src/org/hopandfork/jgnuplot/utility/UpdateChecker.java
+++ b/src/org/hopandfork/jgnuplot/utility/UpdateChecker.java
@@ -9,6 +9,7 @@ import org.hopandfork.jgnuplot.control.PlottableDataController;
 import org.hopandfork.jgnuplot.model.DataFile;
 import org.hopandfork.jgnuplot.model.PlottableData;
 
+@Deprecated
 public class UpdateChecker implements Runnable {
 	private JGP owner;
 

--- a/src/org/hopandfork/jgnuplot/utility/XMLManager.java
+++ b/src/org/hopandfork/jgnuplot/utility/XMLManager.java
@@ -3,6 +3,7 @@ package org.hopandfork.jgnuplot.utility;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+@Deprecated
 public class XMLManager {
 
 	public void addTextNode(Document document, Element parent, String nodeName, String value) {


### PR DESCRIPTION
Deprecates the following classes:
- `JGPFileFilter` - I think it could be rewritten from scratch
- `TempFile` - `File` library class has a `createTempFile()` method, which should be used
- `UpdateChecker` - It should be decoupled from `JGP`
- `XMLManager` - the whole XML serialization process for projects should be refactored 